### PR TITLE
Implement multi-step campaign creation form

### DIFF
--- a/adminportal/app/Http/Controllers/Client/CampaignController.php
+++ b/adminportal/app/Http/Controllers/Client/CampaignController.php
@@ -1,0 +1,162 @@
+<?php
+
+namespace App\Http\Controllers\Client;
+
+use App\Http\Controllers\Controller;
+use App\Http\Requests\Client\Step1Request;
+use App\Http\Requests\Client\Step2Request;
+use App\Http\Requests\Client\Step3Request;
+use App\Http\Requests\Client\Step4Request;
+use App\Models\ClientCampaign;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Str;
+
+class CampaignController extends Controller
+{
+    public function step1Show(Request $request)
+    {
+        $campaign = $this->getCampaignFromSession(optional: true);
+        return view('client.campaign.step1', compact('campaign'));
+    }
+
+    public function step1Store(Step1Request $request): RedirectResponse
+    {
+        $campaign = $this->getCampaignFromSession(optional: true);
+
+        $data = $request->validated();
+
+        if (!$campaign) {
+            $campaign = new ClientCampaign();
+            $campaign->client_id = Auth::id();
+            $campaign->camp_code = $this->generateUniqueCampCode();
+        }
+
+        $campaign->fill([
+            'title' => $data['title'],
+            'objective' => $data['objective'] ?? null,
+            'description' => $data['description'] ?? null,
+            'start_date' => $data['start_date'] ?? null,
+            'end_date' => $data['end_date'] ?? null,
+            'step' => '1',
+        ]);
+        $campaign->save();
+
+        session(['campaign_id' => $campaign->id]);
+
+        return redirect()->route('client.campaign.step2.show')->with('success', 'Step 1 saved. Continue to Step 2.');
+    }
+
+    public function step2Show(Request $request)
+    {
+        $campaign = $this->getCampaignFromSession();
+        if ($campaign->step < '1') {
+            return redirect()->route('client.campaign.step1.show')->with('error', 'Complete Step 1 first.');
+        }
+        return view('client.campaign.step2', compact('campaign'));
+    }
+
+    public function step2Store(Step2Request $request): RedirectResponse
+    {
+        $campaign = $this->getCampaignFromSession();
+        $data = $request->validated();
+
+        $campaign->fill([
+            'age_group' => isset($data['age_group']) ? implode(',', $data['age_group']) : null,
+            'gender' => isset($data['gender']) ? implode(',', $data['gender']) : null,
+            'region' => $data['region'] ?? null,
+            'country' => $data['country'] ?? null,
+            'state' => $data['state'] ?? null,
+            'city' => $data['city'] ?? null,
+            'step' => '2',
+        ])->save();
+
+        return redirect()->route('client.campaign.step3.show')->with('success', 'Step 2 saved. Continue to Step 3.');
+    }
+
+    public function step3Show(Request $request)
+    {
+        $campaign = $this->getCampaignFromSession();
+        if ($campaign->step < '2') {
+            return redirect()->route('client.campaign.step2.show')->with('error', 'Complete Step 2 first.');
+        }
+        return view('client.campaign.step3', compact('campaign'));
+    }
+
+    public function step3Store(Step3Request $request): RedirectResponse
+    {
+        $campaign = $this->getCampaignFromSession();
+        $data = $request->validated();
+
+        $campaign->fill([
+            'ads_place_type' => $data['ads_place_type'],
+            'ads_position' => $data['ads_position'],
+            'budget_type' => $data['budget_type'],
+            'amount' => $data['amount'],
+            'step' => '3',
+        ])->save();
+
+        return redirect()->route('client.campaign.step4.show')->with('success', 'Step 3 saved. Continue to Step 4.');
+    }
+
+    public function step4Show(Request $request)
+    {
+        $campaign = $this->getCampaignFromSession();
+        if ($campaign->step < '3') {
+            return redirect()->route('client.campaign.step3.show')->with('error', 'Complete Step 3 first.');
+        }
+        return view('client.campaign.step4', compact('campaign'));
+    }
+
+    public function step4Store(Step4Request $request): RedirectResponse
+    {
+        $campaign = $this->getCampaignFromSession();
+        $data = $request->validated();
+
+        if ($request->hasFile('ads_file')) {
+            $path = $request->file('ads_file')->store('campaigns', 'public');
+            $campaign->ads_file = $path;
+        }
+
+        $campaign->action_url = $data['action_url'];
+        $campaign->step = '4';
+        $campaign->camp_status = '0';
+        $campaign->status = '0';
+        $campaign->save();
+
+        // Optionally clear session to prevent duplicate submits
+        // session()->forget('campaign_id');
+
+        return redirect()->route('client.campaign.step4.show')->with('success', 'Campaign submitted. Awaiting review.');
+    }
+
+    private function getCampaignFromSession(bool $optional = false): ?ClientCampaign
+    {
+        $campaignId = session('campaign_id');
+        if (!$campaignId) {
+            if ($optional) {
+                return null;
+            }
+            abort(302, '', ['Location' => route('client.campaign.step1.show')]);
+        }
+        $campaign = ClientCampaign::find($campaignId);
+        if (!$campaign) {
+            session()->forget('campaign_id');
+            if ($optional) {
+                return null;
+            }
+            abort(302, '', ['Location' => route('client.campaign.step1.show')]);
+        }
+        return $campaign;
+    }
+
+    private function generateUniqueCampCode(): string
+    {
+        do {
+            $code = 'CAMP-' . now()->format('YmdHis') . '-' . Str::upper(Str::random(6));
+        } while (ClientCampaign::where('camp_code', $code)->exists());
+        return $code;
+    }
+}
+

--- a/adminportal/app/Http/Requests/Client/Step1Request.php
+++ b/adminportal/app/Http/Requests/Client/Step1Request.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Http\Requests\Client;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class Step1Request extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'title' => ['required', 'string', 'max:255'],
+            'objective' => ['nullable', 'string', 'max:50'],
+            'description' => ['nullable', 'string'],
+            'start_date' => ['nullable', 'date'],
+            'end_date' => ['nullable', 'date', 'after_or_equal:start_date'],
+        ];
+    }
+}
+

--- a/adminportal/app/Http/Requests/Client/Step2Request.php
+++ b/adminportal/app/Http/Requests/Client/Step2Request.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Http\Requests\Client;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class Step2Request extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'age_group' => ['nullable', 'array'],
+            'age_group.*' => ['string', 'max:20'],
+            'gender' => ['nullable', 'array'],
+            'gender.*' => ['string', 'max:10'],
+            'region' => ['nullable', 'string', 'max:100'],
+            'country' => ['nullable', 'string', 'max:255'],
+            'state' => ['nullable', 'string', 'max:255'],
+            'city' => ['nullable', 'string', 'max:255'],
+        ];
+    }
+}
+

--- a/adminportal/app/Http/Requests/Client/Step3Request.php
+++ b/adminportal/app/Http/Requests/Client/Step3Request.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Http\Requests\Client;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class Step3Request extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'ads_place_type' => ['required', 'string', 'max:45'],
+            'ads_position' => ['required', 'string', 'max:45'],
+            'budget_type' => ['required', 'string', 'max:45'],
+            'amount' => ['required', 'numeric', 'min:0'],
+        ];
+    }
+}
+

--- a/adminportal/app/Http/Requests/Client/Step4Request.php
+++ b/adminportal/app/Http/Requests/Client/Step4Request.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Http\Requests\Client;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class Step4Request extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'ads_file' => ['nullable', 'file', 'max:5120'],
+            'action_url' => ['required', 'url', 'max:255'],
+        ];
+    }
+}
+

--- a/adminportal/app/Models/ClientCampaign.php
+++ b/adminportal/app/Models/ClientCampaign.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class ClientCampaign extends Model
+{
+    use HasFactory;
+
+    protected $table = 'client_campaign';
+
+    protected $fillable = [
+        'client_id',
+        'camp_code',
+        'title',
+        'objective',
+        'description',
+        'start_date',
+        'end_date',
+        'age_group',
+        'gender',
+        'region',
+        'country',
+        'state',
+        'city',
+        'ads_place_type',
+        'ads_position',
+        'budget_type',
+        'amount',
+        'status',
+        'camp_status',
+        'reason',
+        'step',
+        'ads_file',
+        'action_url',
+    ];
+}
+

--- a/adminportal/database/migrations/2025_09_19_000000_create_client_campaign_table.php
+++ b/adminportal/database/migrations/2025_09_19_000000_create_client_campaign_table.php
@@ -1,0 +1,45 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::create('client_campaign', function (Blueprint $table) {
+            $table->id();
+            $table->unsignedBigInteger('client_id')->nullable();
+            $table->string('camp_code', 100)->unique()->nullable();
+            $table->string('title');
+            $table->string('objective', 50)->nullable();
+            $table->text('description')->nullable();
+            $table->date('start_date')->nullable();
+            $table->date('end_date')->nullable();
+            $table->string('age_group', 50)->nullable();
+            $table->string('gender', 45)->nullable();
+            $table->string('region', 100)->nullable();
+            $table->string('country', 255)->nullable();
+            $table->string('state', 255)->nullable();
+            $table->string('city', 255)->nullable();
+            $table->string('ads_place_type', 45)->nullable();
+            $table->string('ads_position', 45)->nullable();
+            $table->string('budget_type', 45)->nullable();
+            $table->decimal('amount', 10, 2)->default(0);
+            $table->enum('status', ['1','0'])->default('0');
+            $table->enum('camp_status', ['0','1','2','3','4'])->default('0');
+            $table->text('reason')->nullable();
+            $table->enum('step', ['1','2','3','4','5','6'])->default('1');
+            $table->string('ads_file', 255)->nullable();
+            $table->string('action_url', 255)->nullable();
+            $table->timestamps();
+            $table->index('client_id', 'clientCampID');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('client_campaign');
+    }
+};
+

--- a/adminportal/resources/views/client/alert_message.blade.php
+++ b/adminportal/resources/views/client/alert_message.blade.php
@@ -1,0 +1,18 @@
+@if(session('success'))
+    <div class="alert alert-success">{{ session('success') }}</div>
+@endif
+
+@if(session('error'))
+    <div class="alert alert-danger">{{ session('error') }}</div>
+@endif
+
+@if ($errors->any())
+    <div class="alert alert-danger">
+        <ul class="mb-0">
+            @foreach ($errors->all() as $error)
+                <li>{{ $error }}</li>
+            @endforeach
+        </ul>
+    </div>
+@endif
+

--- a/adminportal/resources/views/client/campaign/step1.blade.php
+++ b/adminportal/resources/views/client/campaign/step1.blade.php
@@ -1,0 +1,51 @@
+@extends('client.layouts.default')
+
+@section('content')
+@include('client.alert_message')
+
+<div class="card">
+    <div class="card-header d-flex align-items-center justify-content-between">
+        <h5 class="mb-0">Add Campaign - Step 1 of 4</h5>
+        <div>
+            <span class="badge bg-primary">1</span>
+            <span class="badge bg-secondary">2</span>
+            <span class="badge bg-secondary">3</span>
+            <span class="badge bg-secondary">4</span>
+        </div>
+    </div>
+    <div class="card-body">
+        <form method="POST" action="{{ route('client.campaign.step1.store') }}">
+            @csrf
+            <div class="mb-3">
+                <label class="form-label">Campaign Title</label>
+                <input type="text" name="title" value="{{ old('title', $campaign->title ?? '') }}" class="form-control">
+            </div>
+            <div class="mb-3">
+                <label class="form-label">Campaign Objective</label>
+                <input type="text" name="objective" value="{{ old('objective', $campaign->objective ?? '') }}" class="form-control">
+            </div>
+            <div class="mb-3">
+                <label class="form-label">Campaign Description</label>
+                <textarea name="description" class="form-control" rows="3">{{ old('description', $campaign->description ?? '') }}</textarea>
+            </div>
+            <div class="row g-3">
+                <div class="col-md-6">
+                    <label class="form-label">Start Date</label>
+                    <input type="date" name="start_date" value="{{ old('start_date', isset($campaign->start_date) ? $campaign->start_date : '') }}" class="form-control">
+                </div>
+                <div class="col-md-6">
+                    <label class="form-label">End Date</label>
+                    <input type="date" name="end_date" value="{{ old('end_date', isset($campaign->end_date) ? $campaign->end_date : '') }}" class="form-control">
+                </div>
+            </div>
+            <div class="d-flex justify-content-end mt-4">
+                <a href="{{ url()->previous() }}" class="btn btn-outline-secondary">Cancel</a>
+                <button type="submit" class="btn btn-primary ms-2">Next</button>
+            </div>
+        </form>
+    </div>
+    <div class="card-footer text-muted">Fill required fields to proceed.</div>
+    
+</div>
+@endsection
+

--- a/adminportal/resources/views/client/campaign/step2.blade.php
+++ b/adminportal/resources/views/client/campaign/step2.blade.php
@@ -1,0 +1,72 @@
+@extends('client.layouts.default')
+
+@section('content')
+@include('client.alert_message')
+
+<div class="card">
+    <div class="card-header d-flex align-items-center justify-content-between">
+        <h5 class="mb-0">Add Campaign - Step 2 of 4</h5>
+        <div>
+            <span class="badge bg-success">1</span>
+            <span class="badge bg-primary">2</span>
+            <span class="badge bg-secondary">3</span>
+            <span class="badge bg-secondary">4</span>
+        </div>
+    </div>
+    <div class="card-body">
+        <form method="POST" action="{{ route('client.campaign.step2.store') }}">
+            @csrf
+            <div class="mb-3">
+                <label class="form-label">Target Age Group</label>
+                <select name="age_group[]" class="form-select" multiple>
+                    @php $ageOptions = ['15-25','25-35','35-45','45-65','65-100'];
+                    $selectedAges = old('age_group', isset($campaign->age_group) ? explode(',', $campaign->age_group) : []);
+                    @endphp
+                    @foreach($ageOptions as $option)
+                        <option value="{{ $option }}" {{ in_array($option, $selectedAges) ? 'selected' : '' }}>{{ $option }}</option>
+                    @endforeach
+                </select>
+            </div>
+
+            <div class="mb-3">
+                <label class="form-label">Gender</label>
+                @php $genders = ['Male','Female','Other'];
+                $selectedGenders = old('gender', isset($campaign->gender) ? explode(',', $campaign->gender) : []);
+                @endphp
+                <select name="gender[]" class="form-select" multiple>
+                    @foreach($genders as $g)
+                        <option value="{{ $g }}" {{ in_array($g, $selectedGenders) ? 'selected' : '' }}>{{ $g }}</option>
+                    @endforeach
+                </select>
+            </div>
+
+            <div class="row g-3">
+                <div class="col-md-6">
+                    <label class="form-label">Region</label>
+                    <input type="text" class="form-control" name="region" value="{{ old('region', $campaign->region ?? '') }}">
+                </div>
+                <div class="col-md-6">
+                    <label class="form-label">Country</label>
+                    <input type="text" class="form-control" name="country" value="{{ old('country', $campaign->country ?? '') }}">
+                </div>
+            </div>
+            <div class="row g-3 mt-1">
+                <div class="col-md-6">
+                    <label class="form-label">State</label>
+                    <input type="text" class="form-control" name="state" value="{{ old('state', $campaign->state ?? '') }}">
+                </div>
+                <div class="col-md-6">
+                    <label class="form-label">City</label>
+                    <input type="text" class="form-control" name="city" value="{{ old('city', $campaign->city ?? '') }}">
+                </div>
+            </div>
+
+            <div class="d-flex justify-content-end mt-4">
+                <a href="{{ route('client.campaign.step1.show') }}" class="btn btn-outline-secondary">Back</a>
+                <button type="submit" class="btn btn-primary ms-2">Next</button>
+            </div>
+        </form>
+    </div>
+</div>
+@endsection
+

--- a/adminportal/resources/views/client/campaign/step3.blade.php
+++ b/adminportal/resources/views/client/campaign/step3.blade.php
@@ -1,0 +1,60 @@
+@extends('client.layouts.default')
+
+@section('content')
+@include('client.alert_message')
+
+<div class="card">
+    <div class="card-header d-flex align-items-center justify-content-between">
+        <h5 class="mb-0">Add Campaign - Step 3 of 4</h5>
+        <div>
+            <span class="badge bg-success">1</span>
+            <span class="badge bg-success">2</span>
+            <span class="badge bg-primary">3</span>
+            <span class="badge bg-secondary">4</span>
+        </div>
+    </div>
+    <div class="card-body">
+        <form method="POST" action="{{ route('client.campaign.step3.store') }}">
+            @csrf
+            <div class="mb-3">
+                <label class="form-label">Advertisement Mode</label>
+                @php $modes = ['Banner','Video','Interstitial']; @endphp
+                <select class="form-select" name="ads_place_type">
+                    @foreach($modes as $mode)
+                        <option value="{{ $mode }}" {{ old('ads_place_type', $campaign->ads_place_type ?? '') === $mode ? 'selected' : '' }}>{{ $mode }}</option>
+                    @endforeach
+                </select>
+            </div>
+
+            <div class="mb-3">
+                <label class="form-label">Ads Placement</label>
+                @php $positions = ['Top','Right','Bottom','Left','Center']; @endphp
+                <select class="form-select" name="ads_position">
+                    @foreach($positions as $pos)
+                        <option value="{{ $pos }}" {{ old('ads_position', $campaign->ads_position ?? '') === $pos ? 'selected' : '' }}>{{ $pos }}</option>
+                    @endforeach
+                </select>
+            </div>
+
+            <div class="mb-3">
+                <label class="form-label">Budget</label>
+                <div class="d-flex gap-2">
+                    @php $budgetTypes = ['Daily','Weekly','Monthly','Halfyearly','Yearly']; @endphp
+                    <select class="form-select" style="max-width: 200px" name="budget_type">
+                        @foreach($budgetTypes as $bt)
+                            <option value="{{ $bt }}" {{ old('budget_type', $campaign->budget_type ?? '') === $bt ? 'selected' : '' }}>{{ $bt }}</option>
+                        @endforeach
+                    </select>
+                    <input type="number" step="0.01" min="0" class="form-control" name="amount" placeholder="Amount in USD" value="{{ old('amount', $campaign->amount ?? '') }}">
+                </div>
+            </div>
+
+            <div class="d-flex justify-content-end mt-4">
+                <a href="{{ route('client.campaign.step2.show') }}" class="btn btn-outline-secondary">Back</a>
+                <button type="submit" class="btn btn-primary ms-2">Next</button>
+            </div>
+        </form>
+    </div>
+</div>
+@endsection
+

--- a/adminportal/resources/views/client/campaign/step4.blade.php
+++ b/adminportal/resources/views/client/campaign/step4.blade.php
@@ -1,0 +1,37 @@
+@extends('client.layouts.default')
+
+@section('content')
+@include('client.alert_message')
+
+<div class="card">
+    <div class="card-header d-flex align-items-center justify-content-between">
+        <h5 class="mb-0">Add Campaign - Step 4 of 4</h5>
+        <div>
+            <span class="badge bg-success">1</span>
+            <span class="badge bg-success">2</span>
+            <span class="badge bg-success">3</span>
+            <span class="badge bg-primary">4</span>
+        </div>
+    </div>
+    <div class="card-body">
+        <form method="POST" action="{{ route('client.campaign.step4.store') }}" enctype="multipart/form-data">
+            @csrf
+            <div class="mb-3">
+                <label class="form-label">Ad File Upload</label>
+                <input type="file" name="ads_file" class="form-control">
+                <div class="form-text">The maximum file upload size is 5 MB.</div>
+            </div>
+            <div class="mb-3">
+                <label class="form-label">Call-to-Action Link</label>
+                <input type="url" name="action_url" value="{{ old('action_url', $campaign->action_url ?? '') }}" class="form-control">
+            </div>
+
+            <div class="d-flex justify-content-end mt-4">
+                <a href="{{ route('client.campaign.step3.show') }}" class="btn btn-outline-secondary">Back</a>
+                <button type="submit" class="btn btn-primary ms-2">Submit</button>
+            </div>
+        </form>
+    </div>
+</div>
+@endsection
+

--- a/adminportal/resources/views/client/layouts/default.blade.php
+++ b/adminportal/resources/views/client/layouts/default.blade.php
@@ -1,0 +1,2 @@
+@extends('layouts.app')
+

--- a/adminportal/routes/web.php
+++ b/adminportal/routes/web.php
@@ -12,6 +12,7 @@ use App\Http\Controllers\Admin\ActivityController;
 use App\Http\Controllers\Admin\ImpersonationController;
 use App\Http\Controllers\TwoFactorController;
 use App\Http\Controllers\ProfileController;
+use App\Http\Controllers\Client\CampaignController as ClientCampaignController;
 use App\Http\Middleware\EnsureEmailIsVerifiedIfEnabled;
 
 Route::get('/', function () {
@@ -59,4 +60,19 @@ Route::prefix('admin')->name('admin.')->middleware([EnsureEmailIsVerifiedIfEnabl
     Route::post('/backups', [BackupController::class, 'run'])->name('backups.run');
 
     Route::get('/activity', [ActivityController::class, 'index'])->name('activity.index');
+});
+
+// Client campaign wizard
+Route::prefix('client/campaign')->name('client.campaign.')->group(function () {
+    Route::get('/step-1', [ClientCampaignController::class, 'step1Show'])->name('step1.show');
+    Route::post('/step-1', [ClientCampaignController::class, 'step1Store'])->name('step1.store');
+
+    Route::get('/step-2', [ClientCampaignController::class, 'step2Show'])->name('step2.show');
+    Route::post('/step-2', [ClientCampaignController::class, 'step2Store'])->name('step2.store');
+
+    Route::get('/step-3', [ClientCampaignController::class, 'step3Show'])->name('step3.show');
+    Route::post('/step-3', [ClientCampaignController::class, 'step3Store'])->name('step3.store');
+
+    Route::get('/step-4', [ClientCampaignController::class, 'step4Show'])->name('step4.show');
+    Route::post('/step-4', [ClientCampaignController::class, 'step4Store'])->name('step4.store');
 });


### PR DESCRIPTION
Implement a multi-step campaign creation wizard with per-step validation and persistence.

This PR introduces a four-step campaign creation wizard, ensuring data is validated and saved at each stage before allowing progression to the next. It includes a new `ClientCampaign` model, migration, controller with step guards, dedicated form requests for each step, and separate Blade views to manage the flow.

---
<a href="https://cursor.com/background-agent?bcId=bc-305fe034-b092-471c-a30d-1b2edcbd4aca"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-305fe034-b092-471c-a30d-1b2edcbd4aca"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

